### PR TITLE
Binary response attachments stripped when plugin is enabled

### DIFF
--- a/src/main/java/com/treblle/wso2publisher/handlers/APILogHandler.java
+++ b/src/main/java/com/treblle/wso2publisher/handlers/APILogHandler.java
@@ -576,20 +576,33 @@ public class APILogHandler extends AbstractHandler {
         org.apache.axis2.context.MessageContext axis2MsgContext = ((Axis2MessageContext) messageContext)
                 .getAxis2MessageContext();
 
-        try {
-            RelayUtils.buildMessage(axis2MsgContext);
-        } catch (Exception e) {
-            log.error("[TREBLLE]: Error building message: " + e.getMessage());
-            return null;
-        }
-
-        // Determine content type case-insensitively
+        // Determine content type case-insensitively BEFORE building the message.
         String contentType = null;
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             if ("content-type".equalsIgnoreCase(entry.getKey())) {
                 contentType = entry.getValue().toLowerCase();
                 break;
             }
+        }
+
+        // Never build/consume binary payloads. In the WSO2 pass-through transport a binary
+        // body (e.g. image/png, application/pdf, application/octet-stream) is streamed straight
+        // to the client without being parsed into memory. Calling RelayUtils.buildMessage() on
+        // it drains the pass-through pipe and forces a re-serialization that strips/corrupts the
+        // attachment. We skip body capture for non-text content and let the stream pass through
+        // untouched — request/response metadata (code, headers, size, timing) is still logged.
+        if (contentType != null && !isTextBasedContentType(contentType)) {
+            if (log.isDebugEnabled()) {
+                log.debug("[TREBLLE]: Skipping body capture for binary content type: " + contentType);
+            }
+            return null;
+        }
+
+        try {
+            RelayUtils.buildMessage(axis2MsgContext);
+        } catch (Exception e) {
+            log.error("[TREBLLE]: Error building message: " + e.getMessage());
+            return null;
         }
 
         // Try JSON first — covers application/json and cases where Content-Type is missing/wrong
@@ -632,6 +645,19 @@ public class APILogHandler extends AbstractHandler {
         }
 
         return null;
+    }
+
+    /**
+     * Returns true for content types whose body is safe to build and capture as text.
+     * Anything else (images, PDFs, octet-stream, audio/video, fonts, etc.) is treated as
+     * binary and must not be passed to RelayUtils.buildMessage() in the pass-through flow.
+     */
+    private boolean isTextBasedContentType(String contentType) {
+        return contentType.contains("json")
+                || contentType.contains("xml")
+                || contentType.contains("text/")
+                || contentType.contains("x-www-form-urlencoded")
+                || contentType.contains("multipart/form-data");
     }
 
     private String parseUrlEncodedBodyRaw(String raw) {

--- a/src/test/java/com/treblle/wso2publisher/handlers/APILogHandlerTest.java
+++ b/src/test/java/com/treblle/wso2publisher/handlers/APILogHandlerTest.java
@@ -390,6 +390,65 @@ public class APILogHandlerTest {
     }
 
     @Test
+    public void testIsTextBasedContentType() throws Exception {
+        APILogHandler apiLogHandler = new APILogHandler();
+        Method method = APILogHandler.class.getDeclaredMethod("isTextBasedContentType", String.class);
+        method.setAccessible(true);
+
+        // Text-based types should be captured
+        Assert.assertTrue((boolean) method.invoke(apiLogHandler, "application/json"));
+        Assert.assertTrue((boolean) method.invoke(apiLogHandler, "application/json; charset=utf-8"));
+        Assert.assertTrue((boolean) method.invoke(apiLogHandler, "application/xml"));
+        Assert.assertTrue((boolean) method.invoke(apiLogHandler, "text/plain"));
+        Assert.assertTrue((boolean) method.invoke(apiLogHandler, "text/html"));
+        Assert.assertTrue((boolean) method.invoke(apiLogHandler, "application/x-www-form-urlencoded"));
+        Assert.assertTrue((boolean) method.invoke(apiLogHandler, "multipart/form-data; boundary=x"));
+
+        // Binary types must NOT be captured (so the pass-through stream is left untouched)
+        Assert.assertFalse((boolean) method.invoke(apiLogHandler, "image/png"));
+        Assert.assertFalse((boolean) method.invoke(apiLogHandler, "image/jpeg"));
+        Assert.assertFalse((boolean) method.invoke(apiLogHandler, "application/pdf"));
+        Assert.assertFalse((boolean) method.invoke(apiLogHandler, "application/octet-stream"));
+        Assert.assertFalse((boolean) method.invoke(apiLogHandler, "audio/mpeg"));
+        Assert.assertFalse((boolean) method.invoke(apiLogHandler, "video/mp4"));
+        Assert.assertFalse((boolean) method.invoke(apiLogHandler, "font/woff2"));
+    }
+
+    @Test
+    public void testGetMessageBodyRawSkipsBinaryContent() throws Exception {
+
+        SynapseConfiguration synCfg = new SynapseConfiguration();
+        org.apache.axis2.context.MessageContext axisMsgCtx = new org.apache.axis2.context.MessageContext();
+        AxisConfiguration axisConfig = new AxisConfiguration();
+        ConfigurationContext cfgCtx = new ConfigurationContext(axisConfig);
+        MessageContext synCtx = new Axis2MessageContext(axisMsgCtx, synCfg,
+                new Axis2SynapseEnvironment(cfgCtx, synCfg));
+
+        // Place a readable JSON payload on the message. If getMessageBodyRaw were to build/read
+        // the body for a binary content type, it would return this string. The guard must
+        // short-circuit BEFORE touching the stream, so it returns null for image/png.
+        org.apache.synapse.commons.json.JsonUtil.getNewJsonPayload(
+                axisMsgCtx, "{\"would_be_read\":true}", true, true);
+
+        APILogHandler apiLogHandler = new APILogHandler();
+        Method method = APILogHandler.class.getDeclaredMethod("getMessageBodyRaw", MessageContext.class, Map.class);
+        method.setAccessible(true);
+
+        // Binary response: must skip capture entirely -> null
+        Map<String, String> pngHeaders = new HashMap<>();
+        pngHeaders.put("Content-Type", "image/png");
+        Object pngBody = method.invoke(apiLogHandler, synCtx, pngHeaders);
+        assertNull("Binary (image/png) body must not be captured", pngBody);
+
+        // Text response with the same payload present: should be captured normally
+        Map<String, String> jsonHeaders = new HashMap<>();
+        jsonHeaders.put("Content-Type", "application/json");
+        Object jsonBody = method.invoke(apiLogHandler, synCtx, jsonHeaders);
+        assertNotNull("JSON body should be captured", jsonBody);
+        Assert.assertTrue(((String) jsonBody).contains("would_be_read"));
+    }
+
+    @Test
     public void testPerApiMaskKeywordsOnPayload() throws Exception {
 
         SynapseConfiguration synCfg = new SynapseConfiguration();


### PR DESCRIPTION
Problem
When the Treblle handler was enabled, binary responses (e.g. image/png attachments) were removed/corrupted on the way to the client. With the plugin disabled, they passed through fine.

Root cause
On every response, getMessageBodyRaw() unconditionally called RelayUtils.buildMessage(). In WSO2's pass-through transport, binary bodies normally stream straight to the client without being parsed. Building the message drained and rebuilt that stream, and re-serialization stripped/corrupted the binary content. (The disableResponseBody flag didn't help — the body was built regardless.)

Fix
Detect the Content-Type before building the message and skip body capture entirely for non-text content. Only JSON, XML, text/*, and form-encoded bodies are built/read; image/*, application/pdf, application/octet-stream, audio/video/fonts, etc. are left untouched. Response metadata (status, headers, size, timing) is still logged.

Tests
- testIsTextBasedContentType — classifier returns true for text types, false for binary.
- testGetMessageBodyRawSkipsBinaryContent — returns null for image/png (proves the stream is never touched) while still capturing application/json.